### PR TITLE
Add support for indexing from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,30 @@ apt-get install -y build-essential libsqlite3-dev libssl-dev
 ```
 ## Installation
 On MacOS, for example in `.bash_profile`:
-```
+```shell
 save_cmd() {
     path/to/histx index $(history 1 | awk '{$1=""; print $0}')
 }
 
 export PROMPT_COMMAND=save_cmd
+```
+
+For zsh, set your `pre_cmd()` hook:
+```shell
+    path/to/histx index $(history -1 | awk '{$1=""; print $0}')
+}
+```
+
+## Importing current history
+
+At present, you can import your current history using the `index-in` command:
+
+```shell
+# for zsh
+history 1 | path/to/histx index-in
+
+# for bash
+history | path/to/histx index-in
 ```
 
 ## Usage

--- a/src/main.c
+++ b/src/main.c
@@ -63,6 +63,20 @@ static char *reduce_cmd(char **iter) {
     return cmd;
 }
 
+static char *get_cmd_from_stdin() {
+    char *line = NULL;
+    size_t len = 0;
+    ssize_t linelen = 0;
+    linelen = getline(&line, &len, stdin);
+    if (linelen > 0) {
+        sds cmd = sdsnew(line);
+        free(line);
+        return cmd;
+    } else {
+        return NULL;
+    }
+}
+
 static char *get_home() {
     char *home = getenv("HOME");
     if(home == NULL) {
@@ -96,6 +110,13 @@ int main(int argc, char **argv) {
         sds cmd = reduce_cmd(iter);
         index_cmd(db, cmd);
         sdsfree(cmd);
+    }
+    else if (*iter && strcmp(*iter, "index-in") == 0) {
+        sds cmd;
+        while ((cmd = get_cmd_from_stdin()) != NULL) {
+            index_cmd(db, cmd);
+            sdsfree(cmd);
+        }
     }
     else if(*iter && strcmp(*iter, "find") == 0) {
         iter++;


### PR DESCRIPTION
- adds `index-in` command to import bulk commands
- update `README.md` for zsh config and `index-in`