### PR TITLE
Add tmp file support to explore cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ dkms.conf
 build
 histx.db*
 commands.txt
+.vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ history 1 | path/to/histx index -
 history | path/to/histx index -
 ```
 
+## Reverse Search
+
+### zsh
+
+For zsh, you can create a widget to invoke `histx` for reverse/forward search.
+Explore presently does not have any "directionality" notion per se, so bind
+as you wish.
+
+Example with zle:
+```shell
+function _histx-search {
+  local VISUAL="$PATH_TO_HISTX explore"
+  zle edit-command-line # will invoke $VISUAL with a tmp file name
+  zle accept-line
+}
+
+bindkey "^R" _histx-search # bind traditional emacs mode rev search 
+bindkey -a "/" _histx-search # bind traditional vi mode rev search
+```
+
 ## Usage
 ```
 usage: histx [-d dbfile] <command>

--- a/src/explore.h
+++ b/src/explore.h
@@ -4,6 +4,6 @@
 #include <stdbool.h>
 #include "find.h"
 
-bool explore_cmd(sqlite3 *db);
+bool explore_cmd(sqlite3 *db, FILE *output);
 
 #endif //HISTX_EXPLORE_H

--- a/src/main.c
+++ b/src/main.c
@@ -25,11 +25,11 @@
                     "\t\t-d path/to/db/file.db -- defaults to $HOME/.histx.db or the value of $HISTX_DB_FILE\n" \
                     "\t\t-h this usage information\n" \
                     "\tcommands:\n" \
-                    "\t\tindex   - index all arguments after this command - if the only argument after index is `-` read from stdin\n" \
-                    "\t\tfind    - find matching commands using the the passed keywords\n" \
-                    "\t\tcat     - dump the indexed commands\n" \
-                    "\t\texplore - interactive searching of the index\n"
-
+                    "\t\tindex             - index all arguments after this command - if the only argument after index is `-` read from stdin\n" \
+                    "\t\tfind              - find matching commands using the the passed keywords\n" \
+                    "\t\tcat               - dump the indexed commands\n" \
+                    "\t\texplore [tmpfile] - interactive searching of the index\n"                              \
+                    "\t\t\tIf [tmpfile] is provided, will write the selection (if any) to the tmp file."
 void print_usage_and_exit() {
     fprintf(stderr, HISTX_USAGE);
     exit(1);
@@ -201,7 +201,15 @@ int main(int argc, char **argv) {
         cat_cmd(db, cat_printer);
     }
     else if(*iter && strcmp(*iter, "explore") == 0) {
-        explore_cmd(db);
+        iter++;
+        FILE *output = NULL;
+        if (*iter != NULL) {
+            output = fopen(*iter, "w");
+        }
+        explore_cmd(db, output);
+        if (output != NULL) {
+            fclose(output);
+        }
     }
     sqlite3_close(db);
     return 0;


### PR DESCRIPTION
Primarily for use with zle's `edit-command-line` widget to support
reverse search, I added an optional "tmpfile" argument to explore to
accept a temporary file to write the search selection to, thus then
I can write that to the zle.

Additionally:
 - updated README for zsh reverse search recipe
 - added support for properly reading vi-mode arrow keys