### PR TITLE
Less complex universal search

### DIFF
--- a/src/find.c
+++ b/src/find.c
@@ -18,10 +18,11 @@
 #define SELECT_LUT_FTR      "group by cmdlut.hash order by rank desc, ts desc limit " \
                             TO_STR(SEARCH_LIMIT) \
                             ";"
-                                                                                      \
-#define SELECT_ALL          "select distinct(cmdlut.hash), cmd, ts from cmdlut " \
-                            "inner join cmdraw on cmdlut.hash = cmdraw.hash " \
-                            "group by cmdlut.hash order by ts desc;"
+
+#define SELECT_ALL          "select hash, ts, cmd " \
+                            "from cmdraw "          \
+                            "order by ts asc"       \
+                            ";"
 
 bool concat_handler(uint32_t ngram, void *data) {
     sds *work = (sds *)data;

--- a/src/find.c
+++ b/src/find.c
@@ -21,7 +21,7 @@
 
 #define SELECT_ALL          "select hash, ts, cmd " \
                             "from cmdraw "          \
-                            "order by ts asc"       \
+                            "order by ts desc"       \
                             ";"
 
 bool concat_handler(uint32_t ngram, void *data) {


### PR DESCRIPTION
When the DB gets large, the default query for a universal search doesn't need to be nearly as complex - we're matching at most on two characters, so we can simply pump a reverse universe, by timestamp, into the matcher and get nearly the same results
