### PR TITLE
Allow overriding of search results in `explore`

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install package
-      run: sudo apt-get -y install build-essential libsqlite3-dev libssl-dev flex bison
+      run: sudo apt-get -y install build-essential libsqlite3-dev libssl-dev flex bison libbsd-dev
     - name: make
       run: make all
     - name: test

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DEP := $(OBJ:.o=.d)
 LDFLAGS ?= -lsqlite3
 UNAME := $(shell uname -s)
 ifeq ($(UNAME),Linux)
-	LDFLAGS += -lssl -lcrypto
+	LDFLAGS += -lssl -lcrypto -lbsd
 endif
 
 DIRS := $(shell find $(SRC) -type d)

--- a/src/find.h
+++ b/src/find.h
@@ -5,7 +5,7 @@
 #include <sqlite3.h>
 #include <inttypes.h>
 
-#define SEARCH_LIMIT 5
+extern int SEARCH_LIMIT;
 
 struct hit_context {
     char *cmd;

--- a/src/main.c
+++ b/src/main.c
@@ -188,6 +188,19 @@ int main(int argc, char **argv) {
 
     sdsfree(dbn);
 
+    char *search_limit = get_setting("search-limit");
+    if(search_limit != NULL) {
+        const char *estr = NULL;
+        // the maximum search hits can be between 5 and 20
+        SEARCH_LIMIT = strtonum(search_limit, 5, 20, &estr);
+        if (estr != NULL) {
+            SEARCH_LIMIT = 5;
+        }
+    }
+    else {
+        SEARCH_LIMIT = 5;
+    }
+
     char **iter = argv + optind;
 
     if(*iter && strcmp(*iter, "index") == 0) {

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -155,6 +155,7 @@ void test_config(void) {
     for(int f = 0; falses[f] != NULL; f++) {
         TEST_CHECK(strcmp(get_setting(falses[f]), "false") == 0);
     }
+    destroy_config();
 }
 
 bool test_ngram_count_handler(uint32_t ngram, void *data) {


### PR DESCRIPTION
Add to the options file (`~/.histx`):
```
search-limit = <max-search-hits>
```
...where `max-search-hits` is some number between 5 and 20