### PR TITLE
Add `prune` skeleton command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ histx.db*
 commands.txt
 .vscode
 .DS_Store
+backup.db

--- a/src/explore.c
+++ b/src/explore.c
@@ -21,6 +21,11 @@
 
 #define K_ESC 0x1b
 
+#define K_VI_DOWN 0x6a
+#define K_VI_UP 0x6b
+#define K_VI_PRUNE 0x78
+#define K_VI_INSERT 0x69
+
 #define K_ARROW_VI 0x4f
 #define K_ARROW 0x5b
 #define K_UP    0x41
@@ -40,7 +45,7 @@
 #define PRETTY_SELECT "\e[46m"
 
 #define PRETTY_PRUNE  "\e[45m"
-
+#define PRETTY_PRUNEHOV "\e[4;45m"
 #define PRETTY_CYAN "\e[0;36m"
 #define PRETTY_NORM "\e[0m"
 
@@ -116,13 +121,18 @@ static void reset_non_blocking() {
     tcsetattr(STDIN_FILENO, TCSANOW, &current);
 }
 
-static bool has_input() {
+static bool  has_input(int usec) {
     struct timeval tv;
+    int status;
     fd_set fds;
-    tv.tv_sec = tv.tv_usec = 0;
+    tv.tv_sec = 0;
+    tv.tv_usec = usec;
     FD_ZERO(&fds);
     FD_SET(STDIN_FILENO, &fds);
-    select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv);
+    status = select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv);
+    if (status == 0) {
+        return false;
+    }
     return FD_ISSET(STDIN_FILENO, &fds);
 }
 
@@ -171,6 +181,10 @@ static int select_prune_handler(void *data, int argc, char **argv, char **col) {
     char *ts = NULL;
     uint32_t *counter = (uint32_t *)data;
     *counter = *counter + 1;
+    
+    if (*counter == 1) {
+        printf(PRETTY_PRUNE "### TO BE PRUNED ######################" PRETTY_NORM "\n");
+    }
 
     for(size_t f = 0; f < argc; f++) {
         char *c = *col++;
@@ -198,13 +212,17 @@ static int select_prune_handler(void *data, int argc, char **argv, char **col) {
 static void confirm_prune(sqlite3 *db) {
     char *err;
     uint32_t counter = 0;
-    printf(PRETTY_PRUNE "### TO BE PRUNED ######################" PRETTY_NORM "\n");
     int r = sqlite3_exec(db, SELECT_PRUNE, select_prune_handler, &counter, &err);
     if(r != SQLITE_OK) {
         fprintf(stderr, "Unable to fetch prune candidates: %s\n", err);
         return;
     }
-    printf(PRETTY_PRUNE "#######################################" PRETTY_NORM "\n");
+    if (counter == 0) {
+        printf(PRETTY_PRUNE "Nothing to prune" PRETTY_NORM "\n");
+        return;
+    } else {
+        printf(PRETTY_PRUNE "#######################################" PRETTY_NORM "\n");
+    }
 
     bool confirmed = false;
     char c;
@@ -230,9 +248,12 @@ static void confirm_prune(sqlite3 *db) {
     }
 }
 
-void dump_state(sqlite3 *db, sds *current_line, int *current_selection) {
+void dump_state(sqlite3 *db, sds *current_line, int *current_selection, bool insert) {
     explore_total = 0;
     max_length = 0;
+    if (!insert) {
+        printf("[CMD]");
+    }
     printf("Search: %s\xe2\x96\x88" CLEAR_LINE "\n", *current_line);
     int argc;
     char **split = sdssplitargs(*current_line, &argc);
@@ -253,7 +274,11 @@ void dump_state(sqlite3 *db, sds *current_line, int *current_selection) {
         }
         for(size_t f = 0; f < SEARCH_LIMIT; f++) {
             if(explore_total > 0 && hitsannotations[f] == 1) {
-                printf(PRETTY_PRUNE "%s" PRETTY_NORM CLEAR_LINE "\n", hits[f]);
+                if (f == *current_selection) {
+                    printf(PRETTY_PRUNEHOV "%s" PRETTY_NORM CLEAR_LINE "\n", hits[f]);
+                } else {
+                    printf(PRETTY_PRUNE "%s" PRETTY_NORM CLEAR_LINE "\n", hits[f]);
+                }
             }
             else if(explore_total > 0 && f == *current_selection) {
                 printf(PRETTY_SELECT "%s" PRETTY_NORM CLEAR_LINE "\n", hits[f]);
@@ -293,7 +318,7 @@ bool explore_debug(sqlite3 *db) {
 
     enable_non_blocking();
     while(!explore_done) {
-        if (has_input()) {
+        if (has_input(0)) {
             c = fgetc(stdin);
             if(c == K_ENTER) {
                 explore_done = true;
@@ -308,8 +333,25 @@ bool explore_debug(sqlite3 *db) {
     return true;
 }
 
+int nfgetc(FILE * f) {
+    int c = 0;
+    int r = read(fileno(f), &c, 1);
+    if (r == 1) {
+        return c;
+    }
+    return 0;
+}
+
 bool explore_cmd(sqlite3 *db, FILE *output, uint8_t mode) {
     int c;
+    
+    bool vimode = false;
+    bool command_mode = false;
+    char *vi = get_setting("vi-mode");
+    if (vi != NULL && strcmp(vi, "true") == 0) {
+        vimode = true;
+        command_mode = true; // start in command mode
+    }
 
     hits = (char **)malloc(sizeof(char *) * SEARCH_LIMIT);
     hitsraw = (char **)malloc(sizeof(char *) * SEARCH_LIMIT);
@@ -324,7 +366,7 @@ bool explore_cmd(sqlite3 *db, FILE *output, uint8_t mode) {
     printf(CURSOR_DISABLE);
     int current_selection = 0;
     memset(hits, 0, sizeof(char *) * SEARCH_LIMIT);
-    dump_state(db, &current_line, &current_selection);
+    dump_state(db, &current_line, &current_selection, !command_mode);
     sds selection = NULL;
     term_width = get_term_width();
 
@@ -340,41 +382,64 @@ bool explore_cmd(sqlite3 *db, FILE *output, uint8_t mode) {
     }
 
     while(!explore_done) {
-        if(has_input()) {
+        if(has_input(0)) {
             bool is_arrow = false;
-            c = fgetc(stdin);
+            c = nfgetc(stdin);
             if(c == K_ESC) {
-                c = fgetc(stdin);
-                // I noticed, at least in zsh, if in vi mode you get ^O for arrow instead of ^[
-                // We probably need a more "portable" way to deal with variant termcaps
-                if(c == K_ARROW || c == K_ARROW_VI) {
-                    is_arrow = true;
-                    c = fgetc(stdin);
-                }
+                if (has_input(50000)) {
+                    c = nfgetc(stdin);
+                    // I noticed, at least in zsh, if in vi mode you get ^O for arrow instead of ^[
+                    // We probably need a more "portable" way to deal with variant termcaps
+                    if(c == K_ARROW || c == K_ARROW_VI) {
+                        is_arrow = true;
+                        c = nfgetc(stdin);
+                    }
+                } // else assume pure esc
             }
 
-            if(c == K_ENTER) {
+            if (c == K_ESC) {
+                if (vimode) {
+                    if (!command_mode) {
+                        command_mode = true;
+                        dump_state(db, &current_line, &current_selection, !command_mode);
+                    }
+                } else {
+                    // non vi-mode, we'll just bail
+                    explore_done = true;
+                }
+
+            } else if(c == K_ENTER) {
                 explore_done = true;
                 if(hits[current_selection] != NULL) {
                     selection = sdsnew(hitsraw[current_selection]);
                 }
             }
-            else if(is_arrow && c == K_DOWN) {
+            else if((is_arrow && c == K_DOWN) || (command_mode && c == K_VI_DOWN)) {
                 current_selection++;
-                dump_state(db, &current_line, &current_selection);
+                dump_state(db, &current_line, &current_selection, !command_mode);
             }
-            else if(is_arrow && c == K_UP) {
+            else if((is_arrow && c == K_UP) || (command_mode && c == K_VI_UP)) {
                 current_selection--;
-                dump_state(db, &current_line, &current_selection);
+                dump_state(db, &current_line, &current_selection, !command_mode);
             }
-            else if(c == K_PRUNE && mode == MODE_PRUNE) {
+            else if (is_arrow && mode == MODE_PRUNE) {
+                bool unmark = hitsannotations[current_selection] == 1;
+                if (unmark && c == K_LEFT || !unmark && c == K_RIGHT) {
+                    prune_current(db, hitsraw[current_selection], unmark);
+                    dump_state(db, &current_line, &current_selection, !command_mode);
+                }
+            }
+            else if(mode == MODE_PRUNE && (c == K_PRUNE || (command_mode && c == K_VI_PRUNE))) {
                 bool unmark = hitsannotations[current_selection] == 1;
                 prune_current(db, hitsraw[current_selection], unmark);
-                dump_state(db, &current_line, &current_selection);
+                dump_state(db, &current_line, &current_selection, !command_mode);
+            } else if (command_mode && c == K_VI_INSERT) {
+                command_mode = false;
+                dump_state(db, &current_line, &current_selection, !command_mode);
             }
-            else {
+            else if (!command_mode) {
                 explore_manipulate(&current_line, c);
-                dump_state(db, &current_line, &current_selection);
+                dump_state(db, &current_line, &current_selection, !command_mode);
             }
         }
     }

--- a/src/explore.h
+++ b/src/explore.h
@@ -4,7 +4,10 @@
 #include <stdbool.h>
 #include "find.h"
 
-bool explore_cmd(sqlite3 *db, FILE *output);
+#define MODE_EXPLORE 0x1
+#define MODE_PRUNE 0x2
+
+bool explore_cmd(sqlite3 *db, FILE *output, uint8_t mode);
 bool explore_debug(sqlite3 *db);
 
 #endif //HISTX_EXPLORE_H

--- a/src/find.h
+++ b/src/find.h
@@ -10,6 +10,7 @@ extern int SEARCH_LIMIT;
 struct hit_context {
     char *cmd;
     uint64_t ts;
+    uint8_t annotation_type;
 };
 
 bool find_cmd(sqlite3 *db, char **keywords, bool (*hit_handler)(struct hit_context *));

--- a/src/index.c
+++ b/src/index.c
@@ -58,7 +58,7 @@ static bool insert_lut(sqlite3 *db, uint32_t ngram, char *hash) {
     return true;
 }
 
-char *create_hash(char *src, size_t len) {
+sds create_hash(char *src, size_t len) {
     uint8_t digest[SHA256_DIGEST_LENGTH];
     sds r = sdsempty();
 
@@ -90,7 +90,7 @@ bool ngram_handler_lut(uint32_t ngram, void *data) {
 bool index_cmd(sqlite3 *db, char *cmd) {
     size_t b64len;
     size_t len = strlen(cmd);
-    char *hash = create_hash(cmd, len);
+    sds hash = create_hash(cmd, len);
     char *b64 = (char *)base64_encode((unsigned char *)cmd, len, &b64len);
     bool r = insert_hash(db, hash, b64);
     free(b64);

--- a/src/index.h
+++ b/src/index.h
@@ -3,8 +3,9 @@
 
 #include <stdbool.h>
 #include <sqlite3.h>
+#include "sds.h"
 
-char *create_hash(char *src, size_t len);
+sds create_hash(char *src, size_t len);
 bool index_cmd(sqlite3 *db, char *cmd);
 
 #endif //HISTX_INDEX_H

--- a/src/init.c
+++ b/src/init.c
@@ -10,7 +10,7 @@
                                 "hash text" \
                             ");"
 
-#define LUT_INDEX           "create unique index ngramindex on cmdlut(ngram, hash);"
+#define LUT_INDEX           "create unique index if not exists ngramindex on cmdlut(ngram, hash);"
 
 #define CREATE_TABLE_RAW    "create table if not exists cmdraw (" \
                                 "hash text," \
@@ -18,13 +18,30 @@
                                 "cmd text" \
                             ");"
 
-#define RAW_INDEX           "create unique index hashindex on cmdraw(hash);"
-#define TS_INDEX            "create index tsindex on cmdraw(ts);"
+#define RAW_INDEX           "create unique index if not exists hashindex on cmdraw(hash);"
+#define TS_INDEX            "create index if not exists tsindex on cmdraw(ts);"
+
+#define CREATE_TABLE_AN     "create table if not exists cmdan (" \
+                                "hash text primary key,"         \
+                                "type integer,"                  \
+                                "desc text"                      \
+                            ");"
+
+#define ANNOTATION_INDEX    "create unique index if not exists anindex on cmdan(hash, type);"
 
 bool init(char *dbn, sqlite3 **db) {
     sqlite3 *d;
     char *err;
-    char *seq[] = {CREATE_TABLE_LUT, LUT_INDEX, CREATE_TABLE_RAW, RAW_INDEX, TS_INDEX, NULL};
+    char *seq[] = {
+            CREATE_TABLE_LUT,
+            LUT_INDEX,
+            CREATE_TABLE_RAW,
+            RAW_INDEX,
+            TS_INDEX,
+            CREATE_TABLE_AN,
+            ANNOTATION_INDEX,
+            NULL
+    };
     char **s = &seq[0];
     int r = sqlite3_open(dbn, &d);
     if(r) {

--- a/src/init.c
+++ b/src/init.c
@@ -11,6 +11,7 @@
                             ");"
 
 #define LUT_INDEX           "create unique index if not exists ngramindex on cmdlut(ngram, hash);"
+#define LUT_HASH_INDEX      "create index if not exists ngramhashindex on cmdlut(hash);"
 
 #define CREATE_TABLE_RAW    "create table if not exists cmdraw (" \
                                 "hash text," \
@@ -35,6 +36,7 @@ bool init(char *dbn, sqlite3 **db) {
     char *seq[] = {
             CREATE_TABLE_LUT,
             LUT_INDEX,
+            LUT_HASH_INDEX,
             CREATE_TABLE_RAW,
             RAW_INDEX,
             TS_INDEX,

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,7 @@
 #include "cat.h"
 #include "init.h"
 #include "explore.h"
+#include "util.h"
 
 #define PRETTY_CYAN "\e[0;36m"
 #define PRETTY_NORM "\e[0m"
@@ -44,7 +45,7 @@ void print_usage_and_exit() {
 void check_legal_command(char * cmd) {
     if (cmd == NULL) print_usage_and_exit();
 
-    char *available_commands[] = { "index", "cat", "find", "explore" };
+    char *available_commands[] = { "index", "cat", "find", "explore", "prune" };
     size_t cc = sizeof(available_commands) / sizeof(char*);
     for (int i = 0; i < cc; i++) {
         if (strcmp(cmd, available_commands[i]) == 0) {
@@ -94,23 +95,6 @@ static char *get_home() {
     return home;
 }
 
-static char *format_when(uint64_t delta) {
-    uint32_t secs = delta / 1000;
-    uint32_t mins = secs / 60;
-    uint32_t hours = mins / 60;
-    uint32_t days = hours / 24;
-    if(days > 0) {
-        return sdscatprintf(sdsempty(), "%u day%s ago", days, days > 1 ? "s" : "");
-    }
-    else if(hours > 0) {
-        return sdscatprintf(sdsempty(), "%u hour%s ago", hours, hours > 1 ? "s" : "");
-    }
-    else if(mins > 0) {
-        return sdscatprintf(sdsempty(), "%u minute%s ago", mins, mins > 1 ? "s" : "");
-    }
-    return sdscatprintf(sdsempty(), "A few moments ago");
-}
-
 bool cat_printer(struct hit_context *hit) {
     struct timeval tv;
     tv.tv_sec = hit->ts / 1000;
@@ -124,13 +108,9 @@ bool cat_printer(struct hit_context *hit) {
 }
 
 bool find_printer(struct hit_context *hit) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    uint64_t now = (uint64_t )(tv.tv_sec) * 1000 + (uint64_t )(tv.tv_usec) / 1000;
-    uint64_t delta = now - hit->ts;
-    char *when_pretty = format_when(delta);
-    printf(PRETTY_CYAN "[%s]" PRETTY_NORM " %s\n", when_pretty, hit->cmd);
-    sdsfree(when_pretty);
+    char *when = when_pretty(hit->ts);
+    printf(PRETTY_CYAN "[%s]" PRETTY_NORM " %s\n", when, hit->cmd);
+    sdsfree(when);
     return true;
 }
 
@@ -172,18 +152,9 @@ int main(int argc, char **argv) {
 
     sqlite3 *db;
 
-    if(access(dbn, F_OK) != 0) {
-        if(init(dbn, &db) == false) {
-            fprintf(stderr, "Unable to initialize histx.db\n");
-        }
-    }
-    else {
-        int r = sqlite3_open(dbn, &db);
-        if (r) {
-            fprintf(stderr, "Unable to open %s [%s]\n", dbn, sqlite3_errmsg(db));
-            sqlite3_close(db);
-            return -1;
-        }
+    if(init(dbn, &db) == false) {
+        fprintf(stderr, "Unable to initialize histx.db\n");
+        return -1;
     }
 
     sdsfree(dbn);
@@ -233,10 +204,14 @@ int main(int argc, char **argv) {
         if (*iter != NULL) {
             output = fopen(*iter, "w");
         }
-        explore_cmd(db, output);
+        explore_cmd(db, output, MODE_EXPLORE);
+        //explore_debug(db);
         if (output != NULL) {
             fclose(output);
         }
+    }
+    else if(*iter && strcmp(*iter, "prune") == 0) {
+        explore_cmd(db, NULL, MODE_PRUNE);
     }
     destroy_config();
     sqlite3_close(db);

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,11 @@
 #include <pwd.h>
 #include <sys/time.h>
 #include <time.h>
+
+#if defined(__linux__)
+#include <bsd/bsd.h>
+#endif
+
 #include "config/config.h"
 #include "sds/sds.h"
 #include "index.h"
@@ -33,7 +38,8 @@
                     "\t\tcat               - dump the indexed commands\n" \
                     "\t\texplore [tmpfile] - interactive searching of the index\n"                              \
                     "\t\t                    If [tmpfile] is provided, will write the selection (if any)\n" \
-                    "\t\t                    to the tmp file.\n"
+                    "\t\t                    to the tmp file.\n" \
+                    "\t\tprune             - allows you to mark entries to be pruned from the index via the explore interface\n"
 
 
 

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -44,7 +44,7 @@ static int index_check_handler(void *data, int argc, char **argv, char **col) {
         char *c = *col++;
         char *v = *argv++;
         if(strcmp(c, "hash") == 0) {
-            char *hash = create_hash(input, strlen(input));
+            sds hash = create_hash(input, strlen(input));
             TEST_CHECK(strcmp(v, hash) == 0);
             TEST_MSG("Hash mismatch: expected[%s], found[%s]", hash, v);
             sdsfree(hash);

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,29 @@
+#include <sys/time.h>
+#include <time.h>
+#include "util.h"
+#include "sds/sds.h"
+
+sds when_pretty(uint64_t ts) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    uint64_t now = (uint64_t )(tv.tv_sec) * 1000 + (uint64_t )(tv.tv_usec) / 1000;
+    uint64_t delta = now - ts;
+    return format_when(delta);
+}
+
+sds format_when(uint64_t delta) {
+    uint32_t secs = delta / 1000;
+    uint32_t mins = secs / 60;
+    uint32_t hours = mins / 60;
+    uint32_t days = hours / 24;
+    if(days > 0) {
+        return sdscatprintf(sdsempty(), "%u day%s ago", days, days > 1 ? "s" : "");
+    }
+    else if(hours > 0) {
+        return sdscatprintf(sdsempty(), "%u hour%s ago", hours, hours > 1 ? "s" : "");
+    }
+    else if(mins > 0) {
+        return sdscatprintf(sdsempty(), "%u minute%s ago", mins, mins > 1 ? "s" : "");
+    }
+    return sdscatprintf(sdsempty(), "A few moments ago");
+}

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,10 @@
+#ifndef HISTX_UTIL_H
+#define HISTX_UTIL_H
+
+#include <stdint.h>
+#include "sds/sds.h"
+
+sds format_when(uint64_t delta);
+sds when_pretty(uint64_t ts);
+
+#endif //HISTX_UTIL_H


### PR DESCRIPTION
Adds a `prune` command for removing commands in `histx.db`

`histx prune` works exactly like `histx explore`, except after exploring, commands marked for pruning will be deleted. While using the explorer, `ctl+p` will toggle a command to be pruned.

Additionally, a right arrow keypress will mark for prune, and a left arrow keypress will unmark for pruning

Commands set for pruning are shown in a purple...ish...color