### PR TITLE
Track CWD

### DIFF
--- a/src/find.h
+++ b/src/find.h
@@ -11,6 +11,7 @@ struct hit_context {
     char *cmd;
     uint64_t ts;
     uint8_t annotation_type;
+    char *cwd;
 };
 
 bool find_cmd(sqlite3 *db, char **keywords, bool (*hit_handler)(struct hit_context *));

--- a/src/index.c
+++ b/src/index.c
@@ -95,6 +95,7 @@ bool index_cmd(sqlite3 *db, char *cmd, char *cwd) {
     char *cwdb64 = (char *)base64_encode((unsigned char *)cwd, strlen(cwd), &b64len);
     bool r = insert_hash(db, hash, b64, cwdb64);
     free(b64);
+    free(cwdb64);
     if(r == false) {
         return r;
     }

--- a/src/index.h
+++ b/src/index.h
@@ -6,6 +6,6 @@
 #include "sds.h"
 
 sds create_hash(char *src, size_t len);
-bool index_cmd(sqlite3 *db, char *cmd);
+bool index_cmd(sqlite3 *db, char *cmd, char *cwd);
 
 #endif //HISTX_INDEX_H

--- a/src/init.c
+++ b/src/init.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include "sds/sds.h"
 #include "init.h"
 
 #define CREATE_TABLE_LUT    "create table if not exists cmdlut (" \
@@ -16,7 +17,8 @@
 #define CREATE_TABLE_RAW    "create table if not exists cmdraw (" \
                                 "hash text," \
                                 "ts integer," \
-                                "cmd text" \
+                                "cmd text," \
+                                "cwd text" \
                             ");"
 
 #define RAW_INDEX           "create unique index if not exists hashindex on cmdraw(hash);"
@@ -30,6 +32,67 @@
 
 #define ANNOTATION_INDEX    "create unique index if not exists anindex on cmdan(hash, type);"
 
+#define CREATE_TABLE_VERSION "create table if not exists histxversion (" \
+                                "version integer primary key asc," \
+                                "whence integer" \
+                              ");"
+
+#define M1_ADD_CWD "alter table cmdraw add column cwd text;"
+
+#define FINISH_MIGRATION "insert into histxversion(version, whence) values(%d, unixepoch());"
+
+#define GET_VERSION "select max(version) from histxversion;"
+#define THIS_VERSION 1
+
+
+int getdbversion(sqlite3 *db) {
+
+    const char *sql = GET_VERSION;
+    sqlite3_stmt *stmt;
+    int r = sqlite3_prepare_v2(db, sql, -1, &stmt, 0);
+    if (r != SQLITE_OK) {
+        fprintf(stderr, "Unable to prepare statement: %s\n", sqlite3_errmsg(db));
+        return 0;
+    }
+
+    int value;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        value = sqlite3_column_int(stmt, 0);
+    } else {
+        fprintf(stderr, "Unable to get db version: %s\n", sqlite3_errmsg(db));
+        value = 0;
+    }
+
+    sqlite3_finalize(stmt);
+
+    return value;
+}
+
+bool mark_version(sqlite3 *db, int version) {
+    sds sql = sdsempty();
+    sql = sdscatprintf(sql, FINISH_MIGRATION, version);
+    int r = sqlite3_exec(db, sql, NULL, NULL, NULL);
+    sdsfree(sql);
+    if (r != SQLITE_OK) {
+        fprintf(stderr, "Unable to mark version: %s\n", sqlite3_errmsg(db));
+
+        return false;
+    }
+
+    return true;
+}
+
+bool migrate_1(sqlite3 *db) {
+    int r = sqlite3_exec(db, M1_ADD_CWD, NULL, NULL, NULL);
+    if (r != SQLITE_OK) {
+        fprintf(stderr, "Unable to execute command: %s\n", sqlite3_errmsg(db));
+        return false;
+    }
+
+    mark_version(db, THIS_VERSION);
+    return true;
+}
+
 bool init(char *dbn, sqlite3 **db) {
     sqlite3 *d;
     char *err;
@@ -42,6 +105,7 @@ bool init(char *dbn, sqlite3 **db) {
             TS_INDEX,
             CREATE_TABLE_AN,
             ANNOTATION_INDEX,
+            CREATE_TABLE_VERSION,
             NULL
     };
     char **s = &seq[0];
@@ -55,12 +119,19 @@ bool init(char *dbn, sqlite3 **db) {
     while(*s) {
         r = sqlite3_exec(d, *s++, NULL, NULL, &err);
         if(r != SQLITE_OK) {
-            fprintf(stderr, "Unable to initialize database: %s\n", err);
+            fprintf(stderr, "Unable to initialize database [%s]: %s\n", *s, err);
             sqlite3_free(err);
             return false;
         }
     }
 
     *db = d;
+
+    int dbv = getdbversion(d);
+
+    if (dbv < THIS_VERSION) {
+        bool m = migrate_1(d);
+    }
+
     return true;
 }

--- a/src/init.c
+++ b/src/init.c
@@ -17,8 +17,7 @@
 #define CREATE_TABLE_RAW    "create table if not exists cmdraw (" \
                                 "hash text," \
                                 "ts integer," \
-                                "cmd text," \
-                                "cwd text" \
+                                "cmd text" \
                             ");"
 
 #define RAW_INDEX           "create unique index if not exists hashindex on cmdraw(hash);"

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -78,7 +78,7 @@ void test_index(void) {
     for(size_t f = 0; f < 100; f++) {
         char r = input_set[random() % len];
         input = sdscatprintf(input, "%c", r);
-        TEST_CHECK(index_cmd(db, input));
+        TEST_CHECK(index_cmd(db, input, "bogus"));
         char *err;
         int sr = sqlite3_exec(db, query, index_check_handler, input, &err);
         TEST_CHECK(sr == SQLITE_OK);
@@ -120,7 +120,7 @@ void test_find(void) {
         keywords[0] = input;
         current_input = input;
         current_hit = 0;
-        TEST_CHECK(index_cmd(db, input));
+        TEST_CHECK(index_cmd(db, input, "bogus"));
         TEST_CHECK(find_cmd(db, keywords, find_check_handler));
     }
 


### PR DESCRIPTION
Track the current working directory with the last index of each unique command.  Update the various functions to include this information (if available).

We choose to alter the cmdraw table with a rudimentary and partially completed sql migration convention.  The alternative would be either to use "cmdan" command annotations or a separate table.

For the former (cmdan) the current implementation is pretty dependent on "prune" being the only one.. plus its awkward that it get treated as "optional" metadata moving forward.

For the latter (separate table) this just seems like a bunch of unnecessary joins to add everywhere to avoid doing the db migration. HOWEVER - I may consider going with the separate table, if we decide we want to keep the "history" of working directories the command may have been run in...