### PR TITLE
Remove `cwd` from table create

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -17,8 +17,7 @@
 #define CREATE_TABLE_RAW    "create table if not exists cmdraw (" \
                                 "hash text," \
                                 "ts integer," \
-                                "cmd text," \
-                                "cwd text" \
+                                "cmd text" \
                             ");"
 
 #define RAW_INDEX           "create unique index if not exists hashindex on cmdraw(hash);"


### PR DESCRIPTION
This would only happen on net-new databases, but if `cwd` is added to the table during creation, and the DB version initializes at `1`, then during migration we'd attempt to perform an invalid `alter` (the `cwd` column would already exist)

